### PR TITLE
Avoid prefix clash with dlcd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ index-dlcd:
 	docker-compose exec jupyter bash -c \
 		"cd /opt/odc/scripts && python3 index-cogs-live.py \
 			test.data.frontiersi.io \
-			-p slim-odc-datasets/dlcd \
+			-p slim-odc-datasets/dlcd/ \
 			-e tif \
 			-t dlcd"
 


### PR DESCRIPTION
If you index `dlcd` before `dlcdnsw`, the index script was matching the files starting with `slim-odc-datasets/dlcd-nsw`, as they matched the prefix of `slim-odc-datasets/dlcd`.